### PR TITLE
Laborer states

### DIFF
--- a/Assets/Scripts/Buildings.meta
+++ b/Assets/Scripts/Buildings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ca46e3851691440db23be7cfa16c483
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Buildings/Resources.meta
+++ b/Assets/Scripts/Buildings/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ad3e7b0c72944d85aa3cd9d1b3233d5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Buildings/Storage.meta
+++ b/Assets/Scripts/Buildings/Storage.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0374669c48fe14780b967d2bb5736b69
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Buildings/Storage/BuildSite.cs
+++ b/Assets/Scripts/Buildings/Storage/BuildSite.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BuildSite : MonoBehaviour
+{
+    public GameObject building;
+    public bool readyToBuild = false;
+    public bool materialsDelivered = false;
+    private float _lastBuild = 0f;
+    private int buildProgress = 0;
+    public Dictionary<String, int> _inventory = new Dictionary<String, int>();
+    public Dictionary<String, int> _buildPrerequisites = new Dictionary<String, int>(){{"Wood", 30}, {"Stone", 10}};
+
+    void Start () 
+    {
+      foreach(KeyValuePair<string,int> pair in _buildPrerequisites)
+      {
+        _inventory.Add(pair.Key, 0);
+      }
+    }
+
+    void Update ()
+    {
+      _lastBuild += Time.deltaTime;
+      if (_inventory == _buildPrerequisites && _lastBuild > 30f) readyToBuild = true;
+    }
+
+    public void Build()
+    {
+      _lastBuild = 0f;
+      buildProgress += 10;
+      readyToBuild = false;
+    }
+
+    public bool Give(String resourceType) 
+    {      
+      if (InventoryEqualsPrerequisites()) 
+      {
+        readyToBuild = true;
+        materialsDelivered = true;
+        return false;
+      }
+
+      if (_inventory[resourceType] >= _buildPrerequisites[resourceType]) return false;
+
+      _inventory[resourceType]++;
+
+      return true;
+    }
+
+    public bool InventoryEqualsPrerequisites()
+    {
+      foreach (var pair in _inventory) 
+      {
+        int value;
+        if (_buildPrerequisites.TryGetValue(pair.Key, out value)) {
+          if (value != pair.Value) {
+              return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      return true;
+    }
+}

--- a/Assets/Scripts/Buildings/Storage/BuildSite.cs.meta
+++ b/Assets/Scripts/Buildings/Storage/BuildSite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb493e75a0ce14032ab24c4932f9887a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Buildings/Storage/Storage.cs
+++ b/Assets/Scripts/Buildings/Storage/Storage.cs
@@ -35,13 +35,10 @@ public class Storage : MonoBehaviour
 
     public bool Take(String resourceType) 
     {
-      if (_inventory[resourceType] > 0) 
-      {
-        _inventory[resourceType]--;
-        totalStored--;
-      }
-      if (totalStored <= 0) return false;
+      if (!_inventory.ContainsKey(resourceType) || _inventory[resourceType] <= 0) return false;
 
-      return false;
+      _inventory[resourceType]--;
+      totalStored--;
+      return true;
     }
 }

--- a/Assets/Scripts/Characters.meta
+++ b/Assets/Scripts/Characters.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 8ce6be4bce19a4dbab4be5088fee4ed8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/ObjectPlacer.cs
+++ b/Assets/Scripts/ObjectPlacer.cs
@@ -5,25 +5,27 @@ using UnityEngine;
 public class ObjectPlacer : MonoBehaviour
 {
     public GameObject objectToPlace;
+    private Mesh objectToPlaceMesh;
+    public Material objectPreviewMat;
     private Grid grid;
 
     void Awake()
     {
       grid = FindObjectOfType<Grid>();
+      objectToPlaceMesh = objectToPlace.GetComponent<MeshFilter>().mesh;
     }
 
     // Update is called once per frame
     void Update()
     {
-      if (Input.GetMouseButtonDown(0))
-      {
-        RaycastHit hitInfo;
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+      RaycastHit hitInfo;
+      Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
 
-        if (Physics.Raycast(ray, out hitInfo))
-        {
-            PlaceObjectNear(hitInfo.point);
-        }
+      if (Physics.Raycast(ray, out hitInfo)) Graphics.DrawMesh(objectToPlaceMesh, hitInfo.point, Quaternion.identity, objectPreviewMat, 0);
+
+      if (Input.GetMouseButtonDown(0) && Physics.Raycast(ray, out hitInfo))
+      {
+        PlaceObjectNear(hitInfo.point);
       }
     }
 

--- a/Assets/Scripts/Roles.meta
+++ b/Assets/Scripts/Roles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f29b4964de8d4ecabfc1547b55d8380
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Roles/Laborer.meta
+++ b/Assets/Scripts/Roles/Laborer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55f8e22a0c20a415ba7b1ad28d5f436f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Roles/Laborer/states/FindBuildSite.cs
+++ b/Assets/Scripts/Roles/Laborer/states/FindBuildSite.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using System.Linq;
+
+public class FindBuildSite : IState
+{
+    private readonly Laborer _laborer;
+    public bool isFound;
+
+    public FindBuildSite(Laborer laborer) 
+    {
+      _laborer = laborer;
+    }
+    public void OnEnter() 
+    {
+      _laborer._lastSearch = 0f;
+      isFound = false;
+      BuildSite buildSite = FindActiveBuildSite();
+      if (buildSite != null) 
+      {
+        _laborer.BuildSiteTarget = buildSite;
+        isFound = true;
+      }
+    }
+    public void Tick() 
+    { 
+    }
+
+    public void OnExit() 
+    {
+      _laborer._lastSearch = 0f;
+    }
+
+    private BuildSite FindActiveBuildSite()
+    {
+      return Object.FindObjectsOfType<BuildSite>()
+             .OrderBy(t=> Vector3.Distance(_laborer.transform.position, t.transform.position))
+             .Where(t=> t.materialsDelivered == false)
+             .Take(1)
+             .FirstOrDefault();
+    }
+}

--- a/Assets/Scripts/Roles/Laborer/states/FindBuildSite.cs.meta
+++ b/Assets/Scripts/Roles/Laborer/states/FindBuildSite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c39af1712e7db4918b3877f9237dc32b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Roles/Laborer/states/FindMarkedResource.cs
+++ b/Assets/Scripts/Roles/Laborer/states/FindMarkedResource.cs
@@ -13,7 +13,6 @@ public class FindMarkedResource : IState
     public void OnEnter() 
     {
       isFound = false;
-      _laborer._lastSearch = 0f;
       GatherableResource resource = PickFromResourceType(5);
       if (resource == null) resource = PickFromNearest(5);
       if (resource != null) 

--- a/Assets/Scripts/Roles/Laborer/states/FindStorage.cs
+++ b/Assets/Scripts/Roles/Laborer/states/FindStorage.cs
@@ -13,8 +13,8 @@ public class FindStorage : IState
     public void OnEnter() 
     {
       isFound = false;
+      _laborer.giveToStorage = true;
       _laborer.SetMostResource();
-      // if (_laborer._resourceToDeliver == null) _laborer._resourceToDeliver = "Wood";
       Storage storage = FindCorrectStorage();
       if (storage != null) 
       {

--- a/Assets/Scripts/Roles/Laborer/states/FindStorageToTakeFrom.cs
+++ b/Assets/Scripts/Roles/Laborer/states/FindStorageToTakeFrom.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+using System.Linq;
+
+public class FindStorageToTakeFrom : IState
+{
+    private readonly Laborer _laborer;
+    public bool isFound;
+
+    public FindStorageToTakeFrom(Laborer laborer) 
+    {
+      _laborer = laborer;
+    }
+    public void OnEnter() 
+    {
+      isFound = false;
+      _laborer.takeFromStorage = true;
+      
+      foreach(int num in Enumerable.Range(0, _laborer.BuildSiteTarget._buildPrerequisites.Count))
+      {
+        PickResourceToTake(num);
+      // Check if build site still needs this resource
+        if (_laborer.BuildSiteTarget._inventory.ContainsKey(_laborer._resourceToTake) && _laborer.BuildSiteTarget._inventory[_laborer._resourceToTake] < _laborer.BuildSiteTarget._buildPrerequisites[_laborer._resourceToTake])
+        {
+          break;
+        }
+      }
+
+      Storage storage = FindCorrectStorage();
+      if (storage != null) 
+      {
+        _laborer.StorageTarget = storage;
+        isFound = true;
+      }
+    }
+    public void Tick() 
+    { 
+    }
+
+    public void OnExit() 
+    {
+    }
+
+    private void PickResourceToTake(int index)
+    {
+      _laborer._resourceToTake = _laborer.BuildSiteTarget._buildPrerequisites.Keys.ElementAt(index);
+      if (_laborer.BuildSiteTarget._buildPrerequisites.Values.ElementAt(index) >= _laborer._maxCarry) _laborer._amountToTake = _laborer._maxCarry;
+      else _laborer._amountToTake = _laborer.BuildSiteTarget._buildPrerequisites.Values.ElementAt(index);
+    }
+    private Storage FindCorrectStorage()
+    {
+      return Object.FindObjectsOfType<Storage>()
+             .OrderBy(t=> Vector3.Distance(_laborer.transform.position, t.transform.position))
+             .Where(t=> t.acceptedResources.Contains(_laborer._resourceToTake) && t._inventory[_laborer._resourceToTake] > 0)
+             .Take(1)
+             .FirstOrDefault();
+    }
+}

--- a/Assets/Scripts/Roles/Laborer/states/FindStorageToTakeFrom.cs.meta
+++ b/Assets/Scripts/Roles/Laborer/states/FindStorageToTakeFrom.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab67cfa8673174677bff24a9eeb95750
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Roles/Laborer/states/GiveToBuildSite.cs
+++ b/Assets/Scripts/Roles/Laborer/states/GiveToBuildSite.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class GiveToBuildSite : IState
+{
+    private readonly Laborer _laborer;
+
+    private string _mostResource;
+
+    public GiveToBuildSite(Laborer laborer) 
+    {
+      _laborer = laborer;
+    }
+    public void OnEnter() 
+    {
+    }
+    public void Tick() 
+    { 
+      if (_laborer.BuildSiteTarget != null)
+      {
+        _laborer.GiveToBuildSite();
+      }
+    }
+
+    public void OnExit() 
+    {
+      // _laborer._resourceToTake = "";
+    }
+}

--- a/Assets/Scripts/Roles/Laborer/states/GiveToBuildSite.cs.meta
+++ b/Assets/Scripts/Roles/Laborer/states/GiveToBuildSite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95a67007cfbc14c72ba02c0c4f814118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Roles/Laborer/states/GiveToStorage.cs
+++ b/Assets/Scripts/Roles/Laborer/states/GiveToStorage.cs
@@ -24,6 +24,7 @@ public class GiveToStorage : IState
 
     public void OnExit() 
     {
+      _laborer.giveToStorage = false;
       _laborer.SetMostResource();
     }
 }

--- a/Assets/Scripts/Roles/Laborer/states/GoToBuildSite.cs
+++ b/Assets/Scripts/Roles/Laborer/states/GoToBuildSite.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+public class GoToBuildSite : IState
+{
+    private readonly Laborer _laborer;
+    private readonly NavMeshAgent _navMeshAgent;
+
+    public float TimeStuck;
+    private Vector3 _lastPosition;
+
+    public GoToBuildSite(Laborer laborer, NavMeshAgent navMeshAgent) 
+    {
+      _laborer = laborer;
+      _navMeshAgent = navMeshAgent;
+    }
+    public void OnEnter() 
+    {
+      _navMeshAgent.enabled = true;
+      _navMeshAgent.SetDestination(_laborer.BuildSiteTarget.transform.position);
+  }
+
+    public void Tick() 
+    { 
+    }
+
+    public void OnExit() 
+    {
+      _navMeshAgent.enabled = false; 
+    }
+}

--- a/Assets/Scripts/Roles/Laborer/states/GoToBuildSite.cs.meta
+++ b/Assets/Scripts/Roles/Laborer/states/GoToBuildSite.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc8c3013245a84374999843d15c48e38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Roles/Laborer/states/TakeFromStorage.cs
+++ b/Assets/Scripts/Roles/Laborer/states/TakeFromStorage.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class TakeFromStorage : IState
+{
+    private readonly Laborer _laborer;
+
+    private string _mostResource;
+
+    public TakeFromStorage(Laborer laborer) 
+    {
+      _laborer = laborer;
+    }
+    public void OnEnter() 
+    {
+    }
+    public void Tick() 
+    { 
+      if (_laborer.StorageTarget != null)
+      {
+        _laborer.TakeFromStorage();
+      }
+    }
+
+    public void OnExit() 
+    {
+      _laborer.takeFromStorage = false;
+    }
+}

--- a/Assets/Scripts/Roles/Laborer/states/TakeFromStorage.cs.meta
+++ b/Assets/Scripts/Roles/Laborer/states/TakeFromStorage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 134375673528547418e6ba9e6f194b3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds `BuildSite` class which is a specialized version of storage
Adds states for find and giving a `BuildSite` the required materials

Probably need refactoring to make these states useful across different roles. ie a `builder` role should still be able to use the `FindBuildSite` state